### PR TITLE
Issue #15 - Offers & Creations: add a new section on the landing page

### DIFF
--- a/front-end/messages/en.json
+++ b/front-end/messages/en.json
@@ -14,7 +14,18 @@
     "About": {
         "title"      : "Who are we?",
         "description": "At OMGG (One More Good Game) we are looking to reinvent board games in the digital age.",
-        "text"       : "Our mission is to offer players and creators a new way to imagine, play and share unique experiences, combining the creativity of board games with the codes of video games."
+        "text"       : "Our mission is to offer players and creators a new way to imagine, play and share unique experiences, combining the creativity of board games with the codes of video games.",
+        "more"       : "Learn more",
+        "card1": {
+            "header": "Suggest your game",
+            "text"  : "You're an independent designer or a publisher with a game to digitise, an idea to prototype or a companion application to add? Submit your project to us, and together we'll bring your ideas to life!",
+            "footer": "Submit my project"
+        },
+        "card2": {
+            "header": "Discover our creations",
+            "text"  : "We create immersive experiences while preserving the soul of the games we adapt or prototype. Each project is designed to preserve the game's unique identity, while at the same time enriching it.",
+            "footer": "See our projects"
+        }
     },
     "Logos": {
         "title": "They trusted us"

--- a/front-end/messages/fr.json
+++ b/front-end/messages/fr.json
@@ -14,7 +14,18 @@
     "About": {
         "title"       : "Qui sommes nous ?",
         "description" : "Chez OMGG (One More Good Game) nous cherchons à réinventer le jeu de société à l'ère du numérique.",
-        "text"        : "Notre mission est d'offrir aux joueurs et aux créateurs une nouvelle manière d'imaginer, de jouer et de partager des expériences uniques, en combinant la créativité du jeu de société avec les codes du jeu vidéo."
+        "text"        : "Notre mission est d'offrir aux joueurs et aux créateurs une nouvelle manière d'imaginer, de jouer et de partager des expériences uniques, en combinant la créativité du jeu de société avec les codes du jeu vidéo.",
+        "more"        : "En savoir plus",
+        "card1": {
+            "header": "Proposez votre jeu",
+            "text"  : "Vous êtes créateur indépendant ou une maison d'édition avec un jeu à numériser, une idée à prototyper ou une application compagnon à ajouter ? Soumettez-nous votre projet, et ensemble, nous donnerons vie à vos idées !",
+            "footer": "Soumettre mon projet"
+        },
+        "card2": {
+            "header": "Découvrez nos créations",
+            "text"  : "Nous créons des expériences immersives tout en préservant l'âme des jeux que nous adaptons ou prototypons. Chaque projet est pensé pour garder l'identité unique du jeu, tout en l'enrichissant.",
+            "footer": "Voir nos projets"
+        }
     },
     "Logos": {
         "title": "Ils nous ont fait confiance"

--- a/front-end/src/app/[locale]/page.tsx
+++ b/front-end/src/app/[locale]/page.tsx
@@ -10,6 +10,7 @@ import { Testimonial             } from "@/components/Testimonials/Testimonials"
 import { Logos                   } from "@/components/Logo/Logos";
 import { BlogSectionSlider       } from "@/components/Blog/Blog";
 import { Footer                  } from "@/components/Footer/Footer";
+import { Offers                  } from "@/components/Section/Offers";
 
 import { Footer_Logo } from "@/lib/constants/Footer";
 
@@ -70,7 +71,7 @@ function renderAbout()
       }}
       buttons={{
         primary: {
-          text: "En savoir plus",
+          text: t('more'),
           url: "#",
         }
       }}
@@ -196,6 +197,7 @@ export default function Home({ params }: { params: Promise<{locale: Locale}> })
       {renderNavbar()}
       {renderHero()}
       {renderAbout()}
+      <Offers />
       {renderLogos()}
       <Testimonial />
       <BlogSectionSlider />

--- a/front-end/src/components/Footer/Footer.tsx
+++ b/front-end/src/components/Footer/Footer.tsx
@@ -21,7 +21,7 @@ const Footer = ({ logo, menu }: FooterProps) => {
   return (
     <section className="py-8">
       <Container>
-        <footer className="">
+        <footer>
           <div className="flex flex-col items-center lg:items-start justify-between gap-10 text-center lg:flex-row lg:text-left">
             <div className="flex w-full max-w-96 shrink flex-col items-center justify-between gap-6 lg:items-start">
               {/* Logo */}

--- a/front-end/src/components/Section/Offers.tsx
+++ b/front-end/src/components/Section/Offers.tsx
@@ -1,0 +1,58 @@
+import { Section                                   } from "@/components/Section/Section";
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Button                                    } from "@/components/ui/button";
+import { useTranslations                           } from "next-intl";
+import Link from "next/link";
+
+const Offers = () => {
+  const t = useTranslations('About');
+
+  return (
+    <Section padding={"pb-12"}>
+      <div className="grid items-center gap-8 lg:grid-cols-2 w-full relative">
+        <img src="./OMGG/Illustrations/red_dots.svg" alt="OMGG's dots illustration" className="h-2/3 w-2/3 absolute bottom-28 md:-bottom-44 right-2/3 -z-10 select-none" />
+        <Card className="h-full w-full flex flex-col gap-8 overflow-hidden rounded-2xl shadow-md hover:shadow-xl transition-shadow bg-secondary">
+          <CardHeader>
+            <h2 className="text-2xl md:text-3xl font-bold tracking-tight text-secondary-foreground">
+              {t('card1.header')}
+            </h2>
+          </CardHeader>
+
+          <CardContent className="flex-grow flex flex-col justify-between text-secondary-foreground">
+            {t('card1.text')}
+          </CardContent>
+
+          <CardFooter className="px-5 pb-5 pt-0">
+            <Button asChild size="sm" className="text-sm group justify-start text-primary-foreground max-w-[220px]">
+              <Link href="#" className="flex items-center uppercase">
+                {t('card1.footer')}
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+
+        <Card className="h-full w-full flex flex-col gap-8 overflow-hidden rounded-2xl shadow-md hover:shadow-xl transition-shadow bg-secondary">
+          <CardHeader>
+            <h2 className="text-2xl md:text-3xl font-bold tracking-tight text-secondary-foreground">
+              {t('card2.header')}
+            </h2>
+          </CardHeader>
+
+          <CardContent className="flex-grow flex flex-col justify-between text-secondary-foreground">
+            {t('card2.text')}
+          </CardContent>
+
+          <CardFooter className="px-5 pb-5 pt-0">
+            <Button asChild size="sm" className="w-full text-sm group justify-center text-primary-foreground max-w-[220px]">
+              <Link href="#" className="flex items-center uppercase">
+                {t('card2.footer')}
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </Section>
+  );
+};
+
+export { Offers };

--- a/front-end/src/components/Section/Section.tsx
+++ b/front-end/src/components/Section/Section.tsx
@@ -1,0 +1,24 @@
+import { Container, ContainerContent } from "./Container";
+import { cn                          } from "@/lib/utils";
+
+interface SectionProps {
+  padding     : string; // Padding for the section (e.g., "py-12", "px-4", etc.)
+  background ?: string; // Background color for the section (e.g., "bg-gray-100", "bg-white", etc.)
+  className  ?: string; // Additional class names for the section
+
+  children ?: React.ReactNode; // Children elements to be rendered inside the section
+};
+
+const Section = ({ padding, background, className, children }: SectionProps) => {
+  return (
+    <section className={cn("flex justify-center items-center w-full overflow-hidden", className, padding, background)}>
+      <Container>
+        <ContainerContent>
+          {children}
+        </ContainerContent>
+      </Container>
+    </section>
+  );
+};
+
+export { Section };


### PR DESCRIPTION
## Pull Request

### Description

This pull-request expands the existing “**About**” section on the landing page to include OMGG **offers and creations**.

### Related Issue(s)

#15

### Changes Made

- Creation of a `Section` component using the `Container` component, allowing better handling of sections (footer, navbar, hero, about, blog...)
- Creation of an Offers section.

### Testing

Manual testing in `fr` and `en`, on different screen view.

### Screenshots (if applicable)

![Computer view](https://github.com/user-attachments/assets/91f6145d-ff2f-4356-a517-c8859fa3e932)
![Phone view](https://github.com/user-attachments/assets/2cfea95c-7aac-4129-9efb-aa735e586041)

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Definition of Done
- [x] Extend the about section for offers and creations
- [x] Responsive section
- [x] Multi-Language section  