### PR TITLE
Issue #35 - SEO: Add metadata to all website page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,76 @@
+name: 🐛 Bug Report
+description: Report a reproducible issue with the game or platform
+title: "[BUG] Component - What happens - When it happens"
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please fill out the details below as clearly as possible.
+
+  - type: input
+    id: environment
+    attributes:
+      label: 📋 Environment
+      description: OS, browser, Unity version, etc.
+      placeholder: "Windows 10, Unity 2022.3.5f1, Chrome 115..."
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: Clearly describe the issue or requested feature.
+      placeholder: |
+        If it's a bug, explain what is not working.
+        If it's a feature request, describe what you would like to see implemented.
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: 📸 Screenshots (if applicable)
+      description: Add screenshots to help illustrate the issue or feature request. Use annotations if needed.
+      placeholder: |
+        You can drag and drop images into this field.
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 📌 Steps to Reproduce (if bug)
+      description: Provide detailed steps to reproduce the issue. Be as precise as possible.
+      placeholder: |
+        1. Step 1: ...
+        2. Step 2: ...
+        3. Step 3: ...
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: ✅ Expected Behaviour
+      description: Describe what you expected to happen.
+      placeholder: Explain the intended/normal behaviour.
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: ❌ Observed Behaviour
+      description: Describe what is actually happening and how it differs from the expected result.
+      placeholder: What's going wrong?
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 💡 Possible Solution (optional)
+      description: If you have any suggestions for the cause or fix, include them here.
+      placeholder: Any idea what could be causing this? Suggest a fix if you have one.
+
+  - type: input
+    id: projectVersion
+    attributes:
+      label: 📦 Project Version
+      placeholder: "v1.2.3"
+
+  - type: input
+    id: unityVersion
+    attributes:
+      label: 🎮 Unity Version
+      placeholder: "2022.3.5f1"

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,55 @@
+name: ✨ Feature Request
+description: Suggest an idea or improvement for the project
+title: "[FEATURE] Component - What should be added - Why or when"
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a new feature! Please take a moment to provide detailed information below.
+
+  - type: input
+    id: environment
+    attributes:
+      label: 📋 Environment (optional)
+      description: If this feature is platform-specific, mention it here (OS, Unity version, etc.)
+      placeholder: "Windows 10, Unity 2022.3.5f1"
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Feature Description
+      description: What would you like to see added or changed?
+      placeholder: Describe the idea clearly, including context and intended usage.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 🚀 Motivation and Rationale
+      description: Why is this feature important or useful? What problem does it solve?
+      placeholder: Explain the value or purpose of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 💡 Suggested Solution (optional)
+      description: If you have a specific implementation idea, describe it here.
+      placeholder: Describe how you imagine this could be implemented.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 🔄 Alternatives or workarounds
+      description: Have you considered other ways to achieve the same result?
+      placeholder: Mention any existing solutions or compromises you've tried.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 📎 Additional Context or References
+      description: Add any relevant links, sketches, screenshots, or examples.
+      placeholder: Include images, similar feature references, or design notes if relevant.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+### Description
+Please provide a brief summary of the changes and the purpose of this pull request.
+
+### Related Issue(s)
+Please list any related issue(s) or feature request(s) that are addressed by this pull request. Use the following format: "Fixes #IssueNumber".
+
+### Changes Made
+Please describe the changes made in this pull request. Include relevant details such as new features, bug fixes, or improvements.
+
+### Testing
+Outline the testing steps taken to verify the changes made in this pull request. Include information on any automated tests or manual testing performed.
+
+### Screenshots (if applicable)
+If your changes include visual modifications or new UI elements, please provide screenshots or GIFs demonstrating the changes.
+
+### Checklist
+- [ ] I have tested these changes thoroughly.
+- [ ] The code follows the project's style guide and coding conventions.
+- [ ] I have updated the relevant documentation (if applicable).
+- [ ] All tests passed successfully.
+- [ ] I have checked for any potential conflicts with other branches.
+
+### Additional Notes (if any)
+Add any additional notes, concerns, or information that may be helpful for reviewers.
+
+### Reviewer(s) (optional)
+If you have any specific individuals in mind to review this pull request, you can mention them here.
+
+### Definition of Done
+Specify the criteria that need to be met for this pull request to be considered complete and ready for merging.

--- a/front-end/messages/en.json
+++ b/front-end/messages/en.json
@@ -1,4 +1,8 @@
 {
+    "metadata": {
+        "title": "OMGG | Vos jeux de société, autrement - Digitization and digital adaptation",
+        "description": "One More Good Game transforms your board games into interactive digital experiences. Rediscover your classics, anywhere and anytime."
+    },
     "Navigation": {
         "logoAlt": "OMGG's logo",
         "portfolio": "Our creations",
@@ -82,6 +86,10 @@
         "submit": "Subscribe"
     },
     "Games": {
+        "metadata": {
+            "title": "Vermines | Occult deck-building in the city of bees",
+            "description": "Play as a cultist and sacrifice souls to summon your deity. Vermines, a strategic deck-building game, available in digital version."
+        },
         "hero": {
             "title": "Vermines",
             "badge": "New",

--- a/front-end/messages/fr.json
+++ b/front-end/messages/fr.json
@@ -1,4 +1,8 @@
 {
+    "metadata": {
+        "title": "OMGG | Vos jeux de société, autrement - Numérisation et adaptation digitale",
+        "description": "One More Good Game transforme vos jeux de société en expériences digitales interactives. Redécouvrez vos classiques, partout et à tout moment."
+    },
     "Navigation": {
         "logoAlt": "Logo d'OMGG",
         "portfolio": "Nos créations",
@@ -82,6 +86,10 @@
         "submit": "M'abonner"
     },
     "Games": {
+        "metadata": {
+            "title": "Vermines | Deck-building occulte dans la cité des abeilles",
+            "description": "Incarnez un cultiste et sacrifiez des âmes pour invoquer votre divinité. Vermines, un jeu de deck-building stratégique, disponible en version digitale."
+        },
         "hero": {
             "title": "Vermines",
             "badge": "Nouveau",

--- a/front-end/src/app/[locale]/games/vermines/page.tsx
+++ b/front-end/src/app/[locale]/games/vermines/page.tsx
@@ -1,14 +1,29 @@
-import { Locale, useTranslations } from "next-intl";
-import { setRequestLocale        } from "next-intl/server";
-import { use                     } from "react";
-import { OMGGNewsLetter          } from "@/components/OMGG/Section/NewsLetter";
-import { MediaGallery            } from "@/components/Section/MediaGallery";
-import { HeroTrailerView         } from "@/components/Trailer/HeroTrailerView";
-import { DownloadCTA             } from "@/components/CTA/DownloadCTA";
-import { HeroSection             } from "@/components/Section/Hero";
-import { TextEnum                } from "@/lib/enumerations/TextEnum";
+import { Locale, useTranslations           } from "next-intl";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { OMGGNewsLetter                    } from "@/components/OMGG/Section/NewsLetter";
+import { MediaGallery                      } from "@/components/Section/MediaGallery";
+import { HeroTrailerView                   } from "@/components/Trailer/HeroTrailerView";
+import { DownloadCTA                       } from "@/components/CTA/DownloadCTA";
+import { HeroSection                       } from "@/components/Section/Hero";
+import { TextEnum                          } from "@/lib/enumerations/TextEnum";
+import type { Metadata                     } from "next";
 
 import FadeInWhenVisible from "@/components/Animator/Fade/FadeInWhenVisible";
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata>
+{
+  const { locale } = await params;
+  const t          = await getTranslations({ locale, namespace: "Games" });
+
+  return {
+    title: t("metadata.title"),
+    description: t("metadata.description"),
+    openGraph: {
+      title: t("metadata.title"),
+      description: t("metadata.description")
+    }
+  };
+}
 
 const HeroTrailerSection = () => {
   const t = useTranslations('Games.hero');
@@ -62,9 +77,9 @@ const CTASection = () => {
   );
 }
 
-export default function Home({ params }: { params: Promise<{locale: Locale}> })
+export default async function Home({ params }: { params: Promise<{ locale: Locale }> })
 {
-  const { locale } = use(params);
+  const { locale } = await params;
 
   setRequestLocale(locale);
 

--- a/front-end/src/app/[locale]/page.tsx
+++ b/front-end/src/app/[locale]/page.tsx
@@ -1,19 +1,33 @@
-import { Locale            } from "next-intl";
-import { setRequestLocale  } from "next-intl/server";
-import { use               } from "react";
-import { OMGGTestimonials  } from "@/components/OMGG/Section/Testimonials";
-import { OMGGBlog          } from "@/components/OMGG/Section/Blog";
-import { OMGGOffers        } from "@/components/OMGG/Section/Offers";
-import { OMGGNewsLetter    } from "@/components/OMGG/Section/NewsLetter";
-import { OMGGHero          } from "@/components/OMGG/Section/Hero";
-import { OMGGAbout         } from "@/components/OMGG/Section/About";
-import { OMGGLogos         } from "@/components/OMGG/Section/Logos";
+import { Locale                            } from "next-intl";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { OMGGTestimonials                  } from "@/components/OMGG/Section/Testimonials";
+import { OMGGBlog                          } from "@/components/OMGG/Section/Blog";
+import { OMGGOffers                        } from "@/components/OMGG/Section/Offers";
+import { OMGGNewsLetter                    } from "@/components/OMGG/Section/NewsLetter";
+import { OMGGHero                          } from "@/components/OMGG/Section/Hero";
+import { OMGGAbout                         } from "@/components/OMGG/Section/About";
+import { OMGGLogos                         } from "@/components/OMGG/Section/Logos";
+import type { Metadata                     } from "next";
 
 import FadeInWhenVisible from "@/components/Animator/Fade/FadeInWhenVisible";
 
-export default function Home({ params }: { params: Promise<{locale: Locale}> })
+export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }): Promise<Metadata> {
+  const { locale } = await params;
+  const t          = await getTranslations({ locale, namespace: "metadata" });
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    openGraph: {
+      title: t("title"),
+      description: t("description"),
+    },
+  };
+}
+
+export default async function Home({ params }: { params: Promise<{ locale: Locale }> })
 {
-  const { locale } = use(params);
+  const { locale } = await params;
 
   setRequestLocale(locale);
 

--- a/front-end/src/components/Testimonials/Testimonial.tsx
+++ b/front-end/src/components/Testimonials/Testimonial.tsx
@@ -9,7 +9,7 @@ const Testimonial = (testimonial: TestimonialProps) => {
 
         {/* Avatar */}
         <Avatar className="mb-8 size-24 select-none">
-          <AvatarImage src={testimonial.avatar} />
+          <AvatarImage src={testimonial.avatar} alt={testimonial.name} />
           <AvatarFallback>{testimonial.name}</AvatarFallback>
         </Avatar>
 

--- a/front-end/tsconfig.json
+++ b/front-end/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -8,11 +8,12 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
+    "forceConsistentCasingInFileNames": true,    
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Pull Request

### Description

The aim of this pull request is to give every page on the OMGG website a 100% Lighthouse score for SEO.

### Related Issue(s)

#35

### Changes Made

- Adding `alt` to image that doesn't have it yet.
- Adding metadata to all page with his translation in all location.

### Testing

Lighthouse testing in all page.

### Screenshots (if applicable)

<img width="255" height="163" alt="image" src="https://github.com/user-attachments/assets/8a243ada-3c91-4713-b4a7-6e277101ab05" />
<img width="579" height="326" alt="image" src="https://github.com/user-attachments/assets/71d4f80d-b5e8-4ded-937a-388df3da5f74" />

<img width="246" height="162" alt="image" src="https://github.com/user-attachments/assets/9c0be978-4bd6-4d85-9c82-35b5e125c3a6" />
<img width="577" height="329" alt="image" src="https://github.com/user-attachments/assets/38e014c9-ed16-4374-b3ec-f0e2843713de" />

### Checklist
- [x] I have tested these changes thoroughly.
- [x] The code follows the project's style guide and coding conventions.
- [x] I have updated the relevant documentation (if applicable).
- [x] All tests passed successfully.
- [x] I have checked for any potential conflicts with other branches.

### Definition of Done
- [x] Having a 100% SEO score.